### PR TITLE
トップページの記事取得ロジック変更 and スタイル調整

### DIFF
--- a/home.php
+++ b/home.php
@@ -8,37 +8,36 @@ get_header();
                   'posts_per_page' => 3, // 表示する件数
                   'orderby' => 'date', // 日付でソート
                   'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
-                  'category_name' => 'mv_slide' // 表示したいカテゴリーのスラッグを指定
+                  'tag' => 'mv_slide' // 表示したいカテゴリーのスラッグを指定
               );
         $posts = get_posts( $arg );
         if( $posts ): ?>
-        <?php
-            foreach ($posts as $post):
-              setup_postdata($post); ?>
-              <div>
-                <div class="mv_slide_bg">
-                  <img src="<?php the_post_thumbnail_url('full'); ?>" alt="<?php
-                    $thumbID = get_post_thumbnail_id();
-                    $alt = get_post_meta($thumbID, '_wp_attachment_image_alt', true);
-                    echo $alt;
-                  ?>">
-                </div>
-                <div class="mv_slide_content">
-                  <p class="mv_slide_welcomeMessage">
-                    WELCOME TO <span>GLOW</span>
-                  </p>
-                  <h2 class='mv_slide_text'>
-                    <a href="<?php the_permalink(); ?>">
-                      <?php the_title(); ?>
-                    </a>
-                  </h2>
-                  <div class="mv_slide_readMore">
-                    <div></div>
-                    <a href="<?php the_permalink(); ?>">READ MORE</a>
+          <?php foreach ($posts as $post):
+                setup_postdata($post); ?>
+                <div>
+                  <div class="mv_slide_bg">
+                    <img src="<?php the_post_thumbnail_url('full'); ?>" alt="<?php
+                      $thumbID = get_post_thumbnail_id();
+                      $alt = get_post_meta($thumbID, '_wp_attachment_image_alt', true);
+                      echo $alt;
+                    ?>">
+                  </div>
+                  <div class="mv_slide_content">
+                    <p class="mv_slide_welcomeMessage">
+                      WELCOME TO <span>GLOW</span>
+                    </p>
+                    <h2 class='mv_slide_text'>
+                      <a href="<?php the_permalink(); ?>">
+                        <?php the_title(); ?>
+                      </a>
+                    </h2>
+                    <div class="mv_slide_readMore">
+                      <div></div>
+                      <a href="<?php the_permalink(); ?>">READ MORE</a>
+                    </div>
                   </div>
                 </div>
-              </div>
-      <?php endforeach; ?>
+        <?php endforeach; ?>
       <?php
         endif;
         wp_reset_postdata();
@@ -47,19 +46,25 @@ get_header();
   <div class='mv_posts_container'>
     <?php
       $args = array(
-        'posts_per_page' => 4 // 表示件数の指定
+        'posts_per_page' => 4, // 表示件数の指定
+        'orderby' => 'date', // 日付でソート
+        'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
       );
       $posts = get_posts( $args );
       foreach ( $posts as $post ): // ループの開始
       setup_postdata( $post ); // 記事データの取得
     ?>
-    <div style="background: url(<?php the_post_thumbnail_url('medium'); ?>);" class='mv_post_box'>
-      <div class='mv_post_info'>
-        <?php the_category(); ?>
-        <p class="mv_post_title mb10"><?php the_title(); ?></p>
-        <p class="mv_post_date"><?php the_date(); ?></p>
+      <div style="background: url(<?php the_post_thumbnail_url('medium'); ?>);" class='mv_post_box'>
+        <div class='mv_post_info'>
+          <?php the_category(); ?>
+          <p class="mv_post_title mb10">
+            <a href="<?php the_permalink(); ?>">
+              <?php the_title(); ?>
+            </a>
+          </p>
+          <p class="mv_post_date"><?php the_date(); ?></p>
+        </div>
       </div>
-    </div>
     <?php
       endforeach; // ループの終了
       wp_reset_postdata(); // 直前のクエリを復元する
@@ -68,24 +73,34 @@ get_header();
 </section>
 <section id='news' class='clearfix'>
   <div class='news-inner'>
-    <div class='news_left_container'>
-      <div class='news_heading'><span class="black_stroke">N</span>EWS</div>
-      <div class='news_main_text'>
-        <p>2020年大麻合法化。</p>
-        <p>今世界で起きているグリーンラッシュと</p>
-        <p>日本の未来の話。</p>
-      </div>
-      <div class='news_description'>
-        <p class='mb30'>そこはほか依然としてその意味痛によってのの以上にするですない。とにかく今日をお話家はもしそのままほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨ</p>
-        <p>そこはほか依然としてその意味痛によってのの以上にするですない。とにかく今日をお話家はもしそのままほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨ</p>
-      </div>
-      <div class='news_read_more'>
-        <p>READ MORE</p>
-      </div>
-    </div>
-    <div class='news_right_container'>
-      <img src="<?php echo get_template_directory_uri(); ?>/imgs/weed-politics.png" alt=''>
-    </div>
+    <?php
+      $arg = array(
+                'posts_per_page' => 1, // 表示する件数
+                'orderby' => 'date', // 日付でソート
+                'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
+                'category_name' => 'news' // 表示したいカテゴリーのスラッグを指定
+            );
+      $posts = get_posts( $arg );
+      if( $posts ): ?>
+        <?php foreach ( $posts as $post ) : setup_postdata( $post ); ?>
+          <div class='news_left_container'>
+            <div class='news_heading'><span class="black_stroke">N</span>EWS</div>
+            <div class='news_main_text'>
+              <p><?php the_title(); ?></p>
+            </div>
+            <div class='news_description'>
+              <p><?php the_excerpt(); ?></p>
+            </div>
+            <div class='news_read_more'>
+              <p>READ MORE</p>
+            </div>
+          </div>
+          <div class='news_right_container'>
+            <img src="<?php the_post_thumbnail_url('medium'); ?>" alt=''>
+          </div>
+      <?php endforeach; ?>
+    <?php endif;
+    wp_reset_postdata(); ?>
   </div>
 </section>
 <section id='news_posts'>
@@ -96,7 +111,8 @@ get_header();
     <div class='other_posts_container'>
       <?php
         $arg = array(
-                  'posts_per_page' => 3, // 表示する件数
+                  'posts_per_page' => 4, // 表示する件数
+                  'offset'=> 1, // カテゴリ部分で1記事表示しているのでオフセットする
                   'orderby' => 'date', // 日付でソート
                   'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
                   'category_name' => 'news' // 表示したいカテゴリーのスラッグを指定
@@ -110,7 +126,11 @@ get_header();
               <img src="<?php the_post_thumbnail_url('medium'); ?>" alt='' class='other_post_img'>
               <div class='other_post_info_box'>
                 <?php the_category(); ?>
-                <h2 class='other_post_title mb10'><?php the_title(); ?></h2>
+                <div class='other_post_title mb10'>
+                  <a href="<?php the_permalink(); ?>">
+                    <?php the_title(); ?>
+                  </a>
+                </div>
                 <div class='other_post_datetime'><?php the_date(); ?></div>
               </div>
             </div>
@@ -127,24 +147,34 @@ get_header();
 </section>
 <section id='medical'>
   <div class='medical-inner'>
-    <div class='medical_left_container'>
-      <img src="<?php echo get_template_directory_uri(); ?>/imgs/medical-weed.png" alt=''>
-    </div>
-    <div class='medical_right_container'>
-      <div class='medical_heading'><span class="black_stroke">M</span>EDICAL</div>
-      <div class='medical_main_text'>
-        <p>2020年大麻合法化。</p>
-        <p>今世界で起きているグリーンラッシュと</p>
-        <p>日本の未来の話。</p>
-      </div>
-      <div class='medical_description'>
-        <p class='mb30'>そこはほか依然としてその意味痛によってのの以上にするですない。とにかく今日をお話家はもしそのままほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨ</p>
-        <p>そこはほか依然としてその意味痛によってのの以上にするですない。とにかく今日をお話家はもしそのままほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨほげほげポヨポヨ</p>
-      </div>
-      <div class='medical_read_more'>
-        <p>READ MORE</p>
-      </div>
-    </div>
+    <?php
+      $arg = array(
+                'posts_per_page' => 1, // 表示する件数
+                'orderby' => 'date', // 日付でソート
+                'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
+                'category_name' => 'medical' // 表示したいカテゴリーのスラッグを指定
+            );
+      $posts = get_posts( $arg );
+      if( $posts ): ?>
+        <?php foreach ( $posts as $post ) : setup_postdata( $post ); ?>
+          <div class='medical_left_container'>
+            <img src="<?php the_post_thumbnail_url('medium'); ?>" alt=''>
+          </div>
+          <div class='medical_right_container'>
+            <div class='medical_heading'><span class="black_stroke">M</span>EDICAL</div>
+            <div class='medical_main_text'>
+              <p><?php the_title(); ?></p>
+            </div>
+            <div class='medical_description'>
+              <p><?php the_excerpt(); ?></p>
+            </div>
+            <div class='medical_read_more'>
+              <p>READ MORE</p>
+            </div>
+          </div>
+      <?php endforeach; ?>
+    <?php endif;
+    wp_reset_postdata(); ?>
   </div>
 </section>
 <section id='medical_post'>
@@ -155,7 +185,8 @@ get_header();
     <div class='other_posts_container'>
       <?php
         $arg = array(
-                  'posts_per_page' => 3, // 表示する件数
+                  'posts_per_page' => 4, // 表示する件数
+                  'offset'=> 1, // カテゴリ部分で1記事表示しているのでオフセットする
                   'orderby' => 'date', // 日付でソート
                   'order' => 'DESC', // DESCで最新から表示、ASCで最古から表示
                   'category_name' => 'medical' // 表示したいカテゴリーのスラッグを指定
@@ -169,7 +200,11 @@ get_header();
               <img src="<?php the_post_thumbnail_url('medium'); ?>" alt='' class='other_post_img'>
               <div class='other_post_info_box'>
                 <?php the_category(); ?>
-                <div class='other_post_title mb10'><?php the_title(); ?></div>
+                <div class='other_post_title mb10'>
+                  <a href="<?php the_permalink(); ?>">
+                    <?php the_title(); ?>
+                  </a>
+                </div>
                 <div class='other_post_datetime'><?php the_date(); ?></div>
               </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -15,6 +15,9 @@ Version: 1.0
 .mb60 { margin-bottom: 60px !important; }
 .mb70 { margin-bottom: 70px !important; }
 
+a {
+	text-decoration: none;
+}
 
 .black_stroke {
 	color: #f0f0f0;
@@ -259,7 +262,7 @@ section h2 {
 
 .mv_posts_container {
 	position: sticky;
-	width: 70%;
+	width: 1280px;
 	display: flex;
 	justify-content: space-between;
 	padding: 0 0 150px 0;
@@ -275,13 +278,13 @@ section h2 {
 }
 
 .news-inner {
-	padding: 50px 0 100px 15%;
+	padding: 50px 0 100px 11%;
 	display: flex;
 	justify-content: space-between;
 }
 
 .news_left_container {
-	width: 45%;
+	width: 50%;
 	position: sticky;
 	z-index: 1;
 }
@@ -334,6 +337,12 @@ section h2 {
 	line-height: 2;
 	color: #333;
 	font-size: 0.9rem;
+	margin-bottom: 30px;
+}
+
+.news_description p:last-child,
+.medical_description p:last-child {
+	margin-bottom: 0;
 }
 
 .news_read_more {
@@ -361,7 +370,8 @@ section h2 {
 }
 
 .other_posts_inner {
-	padding: 50px 15% 100px;
+	width: 1280px;
+	padding: 50px 11% 100px;
 }
 
 .news_posts_inner {
@@ -384,7 +394,7 @@ section h2 {
 }
 
 .other_post_box {
-	width: 30%;
+	width: 24%;
 	background: transparent;
 }
 
@@ -405,6 +415,11 @@ section h2 {
 
 .other_post_title {
 	line-height: 1.5;
+}
+
+.mv_post_title a,
+.other_post_title a {
+	color: #fff;
 }
 
 .other_post_datetime {
@@ -432,7 +447,7 @@ section h2 {
 }
 
 .medical-inner {
-	padding: 50px 15% 100px 0;
+	padding: 50px 11% 100px 0;
 	display: flex;
 	justify-content: space-between;
 }
@@ -449,7 +464,7 @@ section h2 {
 }
 
 .medical_right_container {
-	width: 45%;
+	width: 50%;
 	position: sticky;
 	z-index: 1;
 	display: flex;
@@ -498,6 +513,7 @@ section h2 {
 	line-height: 2;
 	color: #333;
 	font-size: 0.9rem;
+	margin-bottom: 30px;
 }
 
 .medical_read_more {


### PR DESCRIPTION
- カテゴリ部分ちょっと仕様変更。Other Postsは４列横並びでお願いします。
- 下のカテゴリセクションは、そのカテゴリページに属する最新記事が、カテゴリ名の下に、
「タイトル」
「抜粋」
「サムネイル」
という形で1記事あって、そのカテゴリに属する最新の2、3、4、5記事がOtherPostsのところに出てくるイメーじ
つまり、カテゴリごとに5記事出る感じだね。
- MVの4記事はカテゴリ関係無しの最新4記事
- MVも一点仕様変更で、カテゴリで抽出ではなく、タグで「mv_slide」がついてるやつをひっぱるようにしよう
MVの4記事のところとかタイトルのaタグすらついてなかったから以上